### PR TITLE
Add an empty line before section titles if there's content before it

### DIFF
--- a/archivebot.py
+++ b/archivebot.py
@@ -58,6 +58,8 @@ def curateurls(wlist=''):
             currentsectionname = line.strip().strip('=').strip()
             if currentsectionname in sectionentries:
                 print('Warning: duplicate section name {!r} on page {}'.format(currentsectionname, wlist.title()))
+            if lines:
+                lines.append('')
             lines.append(line.strip())
         elif line.strip():
             label = ''


### PR DESCRIPTION
For a cleaner `/list` page with visually separated sections