### PR TITLE
Deduplicate URL list and fix sorting with labels

### DIFF
--- a/archivebot.py
+++ b/archivebot.py
@@ -46,7 +46,8 @@ def curateurls(wlist=''):
 
     def endsection():
         nonlocal currentsectionentries, lines, sectionentries, currentsectionname
-        currentsectionentries.sort()
+        currentsectionentries = list(set(currentsectionentries)) # Deduplicate
+        currentsectionentries.sort(key = lambda x: (x[0], x[1] if x[1] is not None else '')) # Sorting a mixture of None and strings is not possible directly
         lines.extend(url + ' | ' + label if label else url for url, label in currentsectionentries)
         sectionentries[currentsectionname] = currentsectionentries
         currentsectionentries = []


### PR DESCRIPTION
Sorting previously failed when there were entries both with and without labels on the same page because Python 3 can't sort a mixture of `None` and strings.