### PR TITLE
Stable sorting

### DIFF
--- a/archivebot.py
+++ b/archivebot.py
@@ -63,7 +63,7 @@ def curateurls(wlist=''):
     def endsection():
         nonlocal currentsectionentries, lines, sectionentries, currentsectionname
         currentsectionentries = list(set(currentsectionentries)) # Deduplicate
-        currentsectionentries.sort(key = lambda x: (x.sorturl, x.label if x.label is not None else ''))
+        currentsectionentries.sort(key = lambda x: (x.sorturl, x.label if x.label is not None else '', x.url, x.line))
         lines.extend(x.line for x in currentsectionentries)
         sectionentries[currentsectionname] = currentsectionentries
         currentsectionentries = []


### PR DESCRIPTION
Previously, when two entries compared equal on the sorturl and label, the order would be random on each run.
Now url and ultimately line are also taken into account. That ensures a stable sort since entries with all-equal values would not matter and be duplicates anyway.