### PR TITLE
Sort ix.io trick URLs by filename and fix a bug in that code

### DIFF
--- a/archivebot.py
+++ b/archivebot.py
@@ -49,7 +49,7 @@ def parselistline(line):
         if domain == 'ix.io' and '+' not in sorturl:
             # Only apply this stripping to the undocumented trick URLs of format ix.io/code+/filename
             continue
-        if sorturl.startswith(domain) and sum(x == '/' for x in sorturl):
+        if sorturl.startswith(domain) and sum(x == '/' for x in sorturl) == 2:
             # For file hosting URLs that contain exactly two slashes, strip the first path component = the random file ID to sort by the filename instead.
             sorturl = domain + sorturl[sorturl.index('/', len(domain) + 1):]
     return Entry(sorturl = sorturl, url = url, label = label, line = line)

--- a/archivebot.py
+++ b/archivebot.py
@@ -45,9 +45,13 @@ def parselistline(line):
         url = url + '/'
     line = url + (' | ' + label if label else '')
     sorturl = truncationpattern.sub('', url).lower()
-    if sorturl.startswith('transfer.sh/') and sum(x == '/' for x in sorturl):
-        # For transfer.sh URLs that contain exactly two slashes, strip the first path component = the random file ID to sort by the filename instead.
-        sorturl = 'transfer.sh' + sorturl[sorturl.index('/', 12):]  # 12 = len('transfer.sh/')
+    for domain in ('transfer.sh', 'ix.io'):
+        if domain == 'ix.io' and '+' not in sorturl:
+            # Only apply this stripping to the undocumented trick URLs of format ix.io/code+/filename
+            continue
+        if sorturl.startswith(domain) and sum(x == '/' for x in sorturl):
+            # For file hosting URLs that contain exactly two slashes, strip the first path component = the random file ID to sort by the filename instead.
+            sorturl = domain + sorturl[sorturl.index('/', len(domain) + 1):]
     return Entry(sorturl = sorturl, url = url, label = label, line = line)
 
 def curateurls(wlist=''):

--- a/archivebottest.py
+++ b/archivebottest.py
@@ -171,7 +171,10 @@ def test_main():
 		 ),
 
 		TestPage(title = 'ArchiveBot/Transfersh/list', textbefore = '\n'.join(['https://transfer.sh/23456/bar', 'https://transfer.sh/12345/foo']), textafter = None, textafterpatterns = None),
-		TestPage(title = 'ArchiveBot/Transfersh', textbefore = '<!-- bot --><!-- /bot -->', textafter = None, textafterpatterns = ['^']) # Don't care about this, just needed to trigger the /list processing
+		TestPage(title = 'ArchiveBot/Transfersh', textbefore = '<!-- bot --><!-- /bot -->', textafter = None, textafterpatterns = ['^']), # Don't care about this, just needed to trigger the /list processing
+
+		TestPage(title = 'ArchiveBot/Ixio/list', textbefore = '\n'.join(['http://ix.io/23456+/bar', 'http://ix.io/12345+/foo']), textafter = None, textafterpatterns = None),
+		TestPage(title = 'ArchiveBot/Ixio', textbefore = '<!-- bot --><!-- /bot -->', textafter = None, textafterpatterns = ['^']),
 	]
 
 	viewerData = {


### PR DESCRIPTION
I forgot to add the `== 2` test when writing that code originally for whatever reason. That meant it tested that there was at least one slash in the URL instead of exactly two (after the domain and after the ID).