### PR TITLE
Fix statistics counting jobs that aren't listed in the table

### DIFF
--- a/archivebot.py
+++ b/archivebot.py
@@ -182,10 +182,10 @@ def main():
                 if viewer[0][0]:
                     viewerplain = "[%s {{saved}}]" % (viewer[0][1])
                     viewerdetailsplain = viewer[0][2]
+                    sectionjobsize += viewer[0][3]
                 else:
                     viewerplain = "[%s {{notsaved}}]" % (viewer[0][1])
                     viewerdetailsplain = ''
-                sectionjobsize += viewer[0][3]
                 rowspan = len(re.findall(r'\|-', viewerdetailsplain))+1
                 rowspanplain = 'rowspan=%d | ' % (rowspan) if rowspan>1 else ''
                 if entry.label:


### PR DESCRIPTION
For example, on [this page](https://archiveteam.org/index.php?title=ArchiveBot/Votes_in_Switzerland/2019-03-24&oldid=36053), the bot counted a job for thomas-vogel.fdp-zh.ch towards the table in the "Parties" section which lists www.fdp-zh.ch.