### PR TITLE
Do not derive the Wikipedia PDF

### DIFF
--- a/archive-wiki-pdf.py
+++ b/archive-wiki-pdf.py
@@ -430,7 +430,7 @@ def archivewikipdf(wikilang='', project='', pagetitle=''):
         'originalurl': originalurl, 
     }
     try:
-        internetarchive.upload(itemid, pdfname, metadata=md)
+        internetarchive.upload(itemid, pdfname, metadata=md, queue_derive=False)
         print('Uploaded to https://archive.org/details/%s' % (itemid))
     except:
         print("Error uploading file to", itemid)


### PR DESCRIPTION
The PDF is itself a derived format so there is not much to gain
from deriving it. An EPUB is best made directly from HTML.

If you don't crowd the derivation queue you can also worry
a bit less about the upload rate.